### PR TITLE
Add Constraints for PEM electricity

### DIFF
--- a/dispatches/case_studies/renewables_case/RE_surrogate_optimization.py
+++ b/dispatches/case_studies/renewables_case/RE_surrogate_optimization.py
@@ -197,6 +197,10 @@ def conceptual_design_dynamic_RE(input_params, num_rep_days, verbose = False, pl
         scenario_model.pem_max_p = Constraint(scenario_model.TIME, 
             rule=lambda b, t: blks[t].fs.pem.electricity[0] <= m.pem_system_capacity)
 
+        # This constraint requires the pem electricity = wind_generated - dispatched.
+        scenario_model.pem_usage = Constraint(scenario_model.TIME,
+            rule=lambda b, t: blks[t].fs.pem.electricity[0] == max(0, clustered_wind_resource[t]-clustered_capacity_factors[t]))
+
         scenario_model.dispatch_frequency = Expression(expr=m.dispatch_surrogate[i])
 
         scenario_model.hydrogen_produced = Expression(scenario_model.TIME,


### PR DESCRIPTION
## Addresses issue:

## Summary/Motivation:
Add a constraint for PEM electricity (consider the infeasibility caused by clustering)

## Changes proposed in this PR:

- Infeasibility caused by clustering is that the capacity of the dispatch representative profile is higher than the corresponding wind representative profile. (K-means will average the data points)

- [ ] Need to check the original data. We are using Day-Ahead wind profile. 


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md and COPYRIGHT.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
